### PR TITLE
set zarr to <=2.18.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "seaborn",
   "session-info",
   "torch",
-  "zarr",
+  "zarr<=2.18.4",
 ]
 optional-dependencies.dev = [
   "pre-commit",


### PR DESCRIPTION
Due to conflict with anndata version 0.11.1. 
closes https://github.com/mengerj/mmcontext/issues/8