### PR TITLE
ci: harden PyPI release workflow and ignore dist/

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,18 @@ jobs:
         with:
           python-version: "3.x"
           cache: "pip"
+      - name: Verify tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "Release tag: $tag / pyproject version: $pkg"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Release tag ($tag) does not match pyproject version ($pkg). Bump the version in pyproject.toml before tagging."
+            exit 1
+          fi
       - run: pip install build
       - run: python -m build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ old_stuff/
 
 #build
 build/
+dist/
 
 #slurm output
 *.err

--- a/docs/agentic_workflow_research.md
+++ b/docs/agentic_workflow_research.md
@@ -184,14 +184,15 @@ The audit discussion feeds into `/plan` → sub-issues → `@claude` implements.
 **What**: Set up a Cowork scheduled task that does similar work to the gh-aw audit, then compare the two approaches.
 
 **Differences**:
-| Aspect | gh-aw | Cowork Scheduled Task |
-|--------|-------|-----------------------|
-| Runs where | GitHub Actions (cloud) | Local (Cowork must be open) |
-| Security | 5-layer guardrails, read-only token | Full local access |
-| Output | GitHub Discussions/Issues | Chat notification in Cowork |
-| Data access | Repo only (sandboxed) | Full local filesystem |
-| Scheduling | Cron via Actions | Cron via Cowork app |
-| Cost | GitHub Actions minutes + LLM tokens | Subscription credit pool |
+
+| Aspect      | gh-aw                               | Cowork Scheduled Task       |
+| ----------- | ----------------------------------- | --------------------------- |
+| Runs where  | GitHub Actions (cloud)              | Local (Cowork must be open) |
+| Security    | 5-layer guardrails, read-only token | Full local access           |
+| Output      | GitHub Discussions/Issues           | Chat notification in Cowork |
+| Data access | Repo only (sandboxed)               | Full local filesystem       |
+| Scheduling  | Cron via Actions                    | Cron via Cowork app         |
+| Cost        | GitHub Actions minutes + LLM tokens | Subscription credit pool    |
 
 **Verdict**: gh-aw for anything that should run reliably regardless of whether your laptop is open. Cowork tasks for things that need local context (your `.venv`, local data files, GPU) or personal briefings.
 


### PR DESCRIPTION
## Summary

Hardens the automated PyPI release workflow so future releases publish automatically without leaving stale failed runs on the repo.

- **Tag/version match guard** — the release job now fails fast with a clear error if the git tag (e.g. `v2.1.0`) does not match `version` in `pyproject.toml`. Catches the most common release mistake (forgetting to bump the version).
- **`skip-existing: true`** on the PyPI publish step — makes re-runs idempotent so a version already on PyPI is skipped instead of failing with a red ✗.
- **Ignore `dist/`** build artifacts.

Targets `main` (not `dev-claude`) because the release workflow runs on `release: published` from `main` and must be present there to take effect.

## Context

`mmcontext 2.0.0` was published to PyPI manually. The previous automated release run (for `v1.0.0-paper`) failed because PyPI trusted publishing wasn't configured yet; that stale failed run has since been deleted. Trusted publishing + a `pypi` environment are now configured on the maintainer's end.

## Follow-up (maintainer)

To publish via the workflow the first time: bump `version` in `pyproject.toml` to a new value (2.0.0 is already on PyPI and cannot be re-uploaded), merge to `main`, then create a GitHub Release with a matching `v<version>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)